### PR TITLE
Feature/climate 3 annual draw generation

### DIFF
--- a/src/climate_data/data.py
+++ b/src/climate_data/data.py
@@ -168,7 +168,6 @@ class ClimateDownscaleData:
         variable: str,
         year: int | str,
         draw: int | str | None,
-        provenance_attribute: str | None,
         encoding_kwargs: dict[str, Any],
     ) -> None:
         path = self.daily_results_path(scenario, variable, year, draw)
@@ -183,9 +182,6 @@ class ClimateDownscaleData:
             "complevel": 1,
         }
         encoding.update(encoding_kwargs)
-
-        # Add the provenance attribute
-        results_ds.attrs["provenance"] = provenance_attribute
 
         results_ds.to_netcdf(path, encoding={"value": encoding})
 

--- a/src/climate_data/data.py
+++ b/src/climate_data/data.py
@@ -204,9 +204,10 @@ class ClimateDownscaleData:
         return self.results / "annual"
 
     def annual_results_path(
-        self, scenario: str, variable: str, year: int | str
+        self, scenario: str, variable: str, year: int | str, draw: int | str | None
     ) -> Path:
-        return self.annual_results / scenario / variable / f"{year}.nc"
+        file_name = f"{year}.nc" if draw is None else f"{year}_{draw}.nc"
+        return self.annual_results / scenario / variable / file_name
 
     def save_annual_results(
         self,
@@ -214,9 +215,10 @@ class ClimateDownscaleData:
         scenario: str,
         variable: str,
         year: int | str,
+        draw: int | str | None,
         encoding_kwargs: dict[str, Any],
     ) -> None:
-        path = self.annual_results_path(scenario, variable, year)
+        path = self.annual_results_path(scenario, variable, year, draw)
         mkdir(path.parent, exist_ok=True, parents=True)
         touch(path, exist_ok=True)
 

--- a/src/climate_data/generate/derived_daily.py
+++ b/src/climate_data/generate/derived_daily.py
@@ -59,7 +59,6 @@ def generate_derived_daily_main(
         variable=target_variable,
         year=year,
         draw=None,
-        provenance_attribute=None,
         encoding_kwargs=transform.encoding_kwargs,
     )
 

--- a/src/climate_data/generate/historical_daily.py
+++ b/src/climate_data/generate/historical_daily.py
@@ -155,7 +155,6 @@ def generate_historical_daily_main(
         variable=target_variable,
         year=year,
         draw=None,
-        provenance_attribute=None,
         encoding_kwargs=transform.encoding_kwargs,
     )
 

--- a/src/climate_data/generate/historical_reference.py
+++ b/src/climate_data/generate/historical_reference.py
@@ -48,7 +48,6 @@ def generate_historical_reference_main(
         variable=target_variable,
         year="reference",
         draw=None,
-        provenance_attribute=None,
         encoding_kwargs=encoding_kwargs,
     )
 

--- a/src/climate_data/generate/scenario_annual.py
+++ b/src/climate_data/generate/scenario_annual.py
@@ -164,6 +164,13 @@ TRANSFORM_MAP = {
 }
 
 
+# Notes about what to do:
+# We want to leave the interface for this function/entry point essentially the same.  We'll add in 
+# a `draw` argument to the task function, but otherwise we'll keep the same interface. 
+# The idea here is to take a target variable in annual space, get all the source variables,
+# compute the daily source variables in memory, then collapse them to the annual target variable.
+
+
 def generate_scenario_annual_main(
     output_dir: str | Path,
     target_variable: str,

--- a/src/climate_data/generate/scenario_annual.py
+++ b/src/climate_data/generate/scenario_annual.py
@@ -154,6 +154,15 @@ TRANSFORM_MAP = {
     ),
 }
 
+# Remove all annual variables dependent on derived_daily variables
+_excluded_source_variables = ["heat_index", "humidex", "effective_temperature"]
+
+TRANSFORM_MAP = {
+    k: v for k, v in TRANSFORM_MAP.items() if not any(
+        source_variable in _excluded_source_variables for source_variable in v.source_variables
+    )
+}
+
 
 def generate_scenario_annual_main(
     output_dir: str | Path,


### PR DESCRIPTION
## Description

Create annual draws from calculated daily draws.  Redo how provenance attributes are included.

## Testing Notes

See output files for a couple of draws here:

/mnt/team/lsae/pub/climate-data/results/annual/ssp585/mean_temperature

reducing cores did not change run time significantly.  See workflows:

https://jobmon-gui.ihme.washington.edu/#?user=billg&tool=&wf_name=&wf_args=&wf_attribute_key=&wf_attribute_value=&wf_id=&date_submitted=2024-11-18&date_submitted_end=2024-11-18&status=
