### PR TITLE
aggregate: skip blocks with no shapefile intersection

### DIFF
--- a/src/climate_data/aggregate/hierarchy.py
+++ b/src/climate_data/aggregate/hierarchy.py
@@ -66,6 +66,8 @@ def hierarchy_main(
     # Get all block keys
     modeling_frame = pm_data.load_modeling_frame()
     block_keys = modeling_frame.block_key.unique()
+    intersecting = utils.blocks_with_shapefile_intersections(hierarchy, pm_data)
+    block_keys = [b for b in block_keys if b in intersecting]
 
     # Load and combine all block-level results
     desc_template = "{draw:5} {block_key:15}"

--- a/src/climate_data/aggregate/pixel.py
+++ b/src/climate_data/aggregate/pixel.py
@@ -169,9 +169,19 @@ def pixel(
     block_keys = modeling_frame["block_key"].unique().tolist()
     block_keys = clio.convert_choice(block_key, block_keys)
 
+    print("Computing per-hierarchy block intersection sets")
+    intersecting_by_hier = {
+        h: utils.blocks_with_shapefile_intersections(h, pm_data)
+        for h in hierarchy
+    }
+
+    hbd = []
+    for h in hierarchy:
+        h_blocks = [b for b in block_keys if b in intersecting_by_hier[h]]
+        hbd.extend(itertools.product([h], h_blocks, draw))
+
     print("Checking for existing results")
     jobs = []
-    hbd = list(itertools.product(hierarchy, block_keys, draw))
     for h, b, d in tqdm.tqdm(hbd):
         if not ca_data.raw_results_path(agg_version, h, b, d).exists():
             jobs.append((h, b, d))

--- a/src/climate_data/aggregate/utils.py
+++ b/src/climate_data/aggregate/utils.py
@@ -212,3 +212,29 @@ def aggregate_climate_to_hierarchy(
     )
     results["value"] = results["weighted_climate"] / results["population"]
     return results
+
+
+def blocks_with_shapefile_intersections(
+    hierarchy: str,
+    pm_data: PopulationModelData,
+) -> set[str]:
+    """Return the set of block_keys whose footprint intersects at least one
+    polygon in the hierarchy's raking shapefile. Blocks not in this set
+    produce empty raw-results (no shape contributes anything), so the
+    pipeline can skip them safely.
+
+    Hierarchy-agnostic: the shapefile lookup is delegated to
+    PopulationModelData.load_raking_shapes, which routes to the right
+    file for whichever hierarchy is in use.
+    """
+    modeling_frame = pm_data.load_modeling_frame()
+    blocks_gdf = (
+        modeling_frame[["block_key", "geometry"]]
+        .dissolve(by="block_key")
+        .reset_index()
+    )
+    shapes = pm_data.load_raking_shapes(hierarchy, bounds=None)
+    if shapes.crs != blocks_gdf.crs:
+        shapes = shapes.to_crs(blocks_gdf.crs)
+    joined = gpd.sjoin(blocks_gdf, shapes, how="inner", predicate="intersects")
+    return set(joined["block_key"].unique())


### PR DESCRIPTION
Adds blocks_with_shapefile_intersections() to aggregate/utils.py and wires it into both the pixel jobmon launcher and hierarchy_main. The helper returns the set of modeling-frame blocks whose footprint intersects at least one polygon in the hierarchy's raking shapefile; blocks outside that set produce empty raw-results (no admin polygon -> empty bounds_map -> zero rows) and can be skipped entirely.

For lsae_1285 against the current shapefile and modeling frame: 528 of 784 blocks intersect; 256 (32.7%) do not. The pixel workflow goes from 78,400 to 52,800 tasks for a single-hierarchy run.

Why it is lossless: hierarchy_main does sum(weighted_climate) / sum(population). A block contributing (0, 0) to a (location_id, year_id) row is identical to that block contributing no row at all. Empty-bounds-map blocks already wrote empty parquets that contributed zero rows -- the math is unchanged by simply not running them.

Design:
- The intersecting set is computed on the fly at both call sites (pixel launcher and hierarchy_main); no persisted skip-list artifact. Inputs (modeling_frame.parquet + raking shapefile) are stable team-owned files, and the sjoin takes ~22s.
- Filter criterion is shape-intersection, not population-NaN. Shape intersection is time-invariant; pop-NaN would require scanning 151 yearly TIFFs and could false-positive in years where a block first becomes inhabited.
- The helper is hierarchy-agnostic: shape lookup is delegated to PopulationModelData.load_raking_shapes, which already routes per hierarchy.

Downstream: no changes. results/<hierarchy>/<measure>_<scenario>.parquet output is bit-for-bit unchanged because the dropped block contributions were already zero.

## Description

A short description about the changes in this pull request. If the pull request is related to some issue, mention it
 here.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
