### PR TITLE
Feature/climate 21 dry run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Dry-run preview for cluster runners: `jobmon_utils.run_parallel_maybe_dry_run`
+  and a `--dry-run/--no-dry-run` option (`clio.with_dry_run`) threaded through the
+  runners; prints sbatch-like job previews instead of submitting. (CLIMATE-21)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,9 @@ ignore = [
 "scripts/**" = [
     "INP001",   # "Scripts are not part of a package."
 ]
+"src/climate_data/jobmon_utils.py" = [
+    "PERF401",  # billg hates list comprehensions
+]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10

--- a/src/climate_data/aggregate/hierarchy.py
+++ b/src/climate_data/aggregate/hierarchy.py
@@ -11,12 +11,12 @@ The compilation process:
 import click
 import pandas as pd
 import tqdm
-from rra_tools import jobmon
 
 from climate_data import cli_options as clio
 from climate_data import constants as cdc
 from climate_data.aggregate import utils
 from climate_data.data import ClimateAggregateData, PopulationModelData
+from climate_data.jobmon_utils import run_parallel_maybe_dry_run
 
 
 def hierarchy_main(
@@ -182,6 +182,7 @@ def hierarchy_task(
 @clio.with_input_directory("population-model", cdc.POPULATION_MODEL_ROOT)
 @clio.with_output_directory(cdc.AGGREGATE_ROOT)
 @clio.with_queue()
+@clio.with_dry_run()
 def hierarchy(
     agg_version: str,
     hierarchy: list[str],
@@ -190,6 +191,7 @@ def hierarchy(
     population_model_dir: str,
     output_dir: str,
     queue: str,
+    dry_run: bool,
 ) -> None:
     """Collate block-level datasets into measure-level datasets.
 
@@ -203,7 +205,7 @@ def hierarchy(
     n_jobs = len(hierarchy) * len(agg_measure) * len(agg_scenario)
     print(f"Running {n_jobs} jobs")
 
-    jobmon.run_parallel(
+    run_parallel_maybe_dry_run(
         runner="cdtask aggregate",
         task_name="hierarchy",
         node_args={
@@ -225,4 +227,5 @@ def hierarchy(
         },
         log_root=ca_data.log_dir("aggregate_hierarchy"),
         max_attempts=3,
+        dry_run=dry_run,
     )

--- a/src/climate_data/aggregate/pixel.py
+++ b/src/climate_data/aggregate/pixel.py
@@ -4,7 +4,6 @@ import click
 import numpy as np
 import pandas as pd
 import tqdm
-from rra_tools import jobmon
 
 from climate_data import cli_options as clio
 from climate_data import constants as cdc
@@ -14,6 +13,7 @@ from climate_data.data import (
     ClimateData,
     PopulationModelData,
 )
+from climate_data.jobmon_utils import run_parallel_maybe_dry_run
 from climate_data.utils import to_raster
 
 
@@ -153,6 +153,7 @@ def pixel_task(
 @clio.with_input_directory("climate-data", cdc.MODEL_ROOT)
 @clio.with_output_directory(cdc.AGGREGATE_ROOT)
 @clio.with_queue()
+@clio.with_dry_run()
 def pixel(
     agg_version: str,
     block_key: str,
@@ -162,6 +163,7 @@ def pixel(
     climate_data_dir: str,
     output_dir: str,
     queue: str,
+    dry_run: bool,
 ) -> None:
     ca_data = ClimateAggregateData(output_dir)
     pm_data = PopulationModelData(population_model_dir)
@@ -178,7 +180,7 @@ def pixel(
     jobs = list(set(jobs))
 
     print(f"Running {len(jobs)} jobs")
-    jobmon.run_parallel(
+    run_parallel_maybe_dry_run(
         runner="cdtask aggregate",
         task_name="pixel",
         flat_node_args=(
@@ -200,4 +202,5 @@ def pixel(
         },
         log_root=ca_data.log_dir("aggregate_pixel"),
         max_attempts=3,
+        dry_run=dry_run,
     )

--- a/src/climate_data/cli_options.py
+++ b/src/climate_data/cli_options.py
@@ -251,6 +251,17 @@ def with_location_id[**P, T]() -> Callable[[Callable[P, T]], Callable[P, T]]:
     )
 
 
+def with_dry_run[**P, T]() -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """Add dry-run flag to a command."""
+    return click.option(
+        "--dry-run/--no-dry-run",
+        "-n",
+        default=False,
+        show_default=True,
+        help="Print sbatch-like previews instead of submitting jobs.",
+    )
+
+
 __all__ = [
     "RUN_ALL",
     "convert_choice",
@@ -278,4 +289,6 @@ __all__ = [
     "with_target_variable",
     "with_verbose",
     "with_year",
+    "with_location_id",
+    "with_dry_run",
 ]

--- a/src/climate_data/diagnostics/grid_plots.py
+++ b/src/climate_data/diagnostics/grid_plots.py
@@ -3,12 +3,13 @@ import contextily as ctx
 import matplotlib.pyplot as plt
 import seaborn as sns
 from requests.exceptions import HTTPError
-from rra_tools import jobmon, plotting
+from rra_tools import plotting
 
 import climate_data.cli_options as clio
 import climate_data.constants as cdc
 from climate_data.data import ClimateAggregateData, PopulationModelData
 from climate_data.diagnostics.utils import load_climate_data, load_populations
+from climate_data.jobmon_utils import run_parallel_maybe_dry_run
 
 FIG_SIZE = (35, 20)
 GRID_SPEC_MARGINS = {"top": 0.92, "bottom": 0.08}
@@ -240,12 +241,14 @@ def grid_plots_task(
 @clio.with_input_directory("population-model", cdc.POPULATION_MODEL_ROOT)
 @clio.with_output_directory(cdc.AGGREGATE_ROOT)
 @clio.with_queue()
+@clio.with_dry_run()
 def grid_plots(
     agg_version: str,
     hierarchy: list[str],
     population_model_dir: str,
     output_dir: str,
     queue: str,
+    dry_run: bool,
 ) -> None:
     pm_data = PopulationModelData(population_model_dir)
     ca_data = ClimateAggregateData(output_dir)
@@ -263,7 +266,7 @@ def grid_plots(
 
     print(f"Running {len(jobs)} jobs")
 
-    jobmon.run_parallel(
+    run_parallel_maybe_dry_run(
         runner="cdtask diagnostics",
         task_name="grid_plots",
         flat_node_args=(
@@ -284,17 +287,18 @@ def grid_plots(
         },
         log_root=ca_data.log_dir("diagnostics_grid_plots"),
         max_attempts=3,
+        dry_run=dry_run,
     )
 
     for h in hierarchy:
         loc_meta = pm_data.load_subset_hierarchy(h)
-        plot_cache = ca_data.grid_plots_pages_root(version, h)
-        output_path = ca_data.grid_plots_path(version, h)
+        plot_cache = ca_data.grid_plots_pages_root(agg_version, h)
+        output_path = ca_data.grid_plots_path(agg_version, h)
         for loc_id in loc_meta.location_id.unique():
             if plot_cache.exists(loc_id):
                 print(f"Skipping {loc_id} because it already exists")
                 continue
             print(f"Processing {loc_id}")
             grid_plots_main(
-                loc_id, version, h, population_model_dir, output_dir, write=False
+                loc_id, agg_version, h, population_model_dir, output_dir, write=False
             )

--- a/src/climate_data/downscale/prepare_predictors.py
+++ b/src/climate_data/downscale/prepare_predictors.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import click
 import numpy as np
 import rasterra as rt
-from rra_tools import jobmon
 
 from climate_data import (
     cli_options as clio,
@@ -13,6 +12,7 @@ from climate_data import (
     constants as cdc,
 )
 from climate_data.data import ClimateData
+from climate_data.jobmon_utils import run_parallel_maybe_dry_run
 from climate_data.utils import make_raster_template
 
 PAD = 1
@@ -156,8 +156,13 @@ def prepare_predictors_task(
 @click.command()
 @clio.with_output_directory(cdc.MODEL_ROOT)
 @clio.with_queue()
-def prepare_predictors(output_dir: str, queue: str) -> None:
-    jobmon.run_parallel(
+@clio.with_dry_run()
+def prepare_predictors(
+    output_dir: str,
+    queue: str,
+    dry_run: bool,
+) -> None:
+    run_parallel_maybe_dry_run(
         runner="cdtask",
         task_name="downscale prepare_predictors",
         node_args={
@@ -174,4 +179,5 @@ def prepare_predictors(output_dir: str, queue: str) -> None:
             "runtime": "45m",
             "project": "proj_rapidresponse",
         },
+        dry_run=dry_run,
     )

--- a/src/climate_data/downscale/prepare_training_data.py
+++ b/src/climate_data/downscale/prepare_training_data.py
@@ -5,7 +5,6 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import xarray as xr
-from rra_tools import jobmon
 
 from climate_data import (
     cli_options as clio,
@@ -14,6 +13,7 @@ from climate_data import (
     constants as cdc,
 )
 from climate_data.data import ClimateData
+from climate_data.jobmon_utils import run_parallel_maybe_dry_run
 
 
 def load_and_clean_climate_stations(
@@ -115,8 +115,13 @@ def prepare_training_data_task(year: str, output_dir: str) -> None:
 @click.command()
 @clio.with_output_directory(cdc.MODEL_ROOT)
 @clio.with_queue()
-def prepare_training_data(output_dir: str, queue: str) -> None:
-    jobmon.run_parallel(
+@clio.with_dry_run()
+def prepare_training_data(
+    output_dir: str,
+    queue: str,
+    dry_run: bool,
+) -> None:
+    run_parallel_maybe_dry_run(
         runner="cdtask",
         task_name="downscale prepare_training_data",
         node_args={
@@ -132,4 +137,5 @@ def prepare_training_data(output_dir: str, queue: str) -> None:
             "runtime": "30m",
             "project": "proj_rapidresponse",
         },
+        dry_run=dry_run,
     )

--- a/src/climate_data/extract/cmip6.py
+++ b/src/climate_data/extract/cmip6.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import click
 import gcsfs
 import xarray as xr
-from rra_tools import jobmon, shell_tools
+from rra_tools import shell_tools
 
 from climate_data import (
     cli_options as clio,
@@ -17,6 +17,7 @@ from climate_data import (
     constants as cdc,
 )
 from climate_data.data import ClimateData
+from climate_data.jobmon_utils import run_parallel_maybe_dry_run
 
 
 def load_cmip_data(zarr_path: str) -> xr.Dataset:
@@ -120,6 +121,7 @@ def extract_cmip6_task(
 @clio.with_output_directory(cdc.MODEL_ROOT)
 @clio.with_queue()
 @clio.with_overwrite()
+@clio.with_dry_run()
 def extract_cmip6(
     cmip6_source: list[str],
     cmip6_experiment: list[str],
@@ -127,6 +129,7 @@ def extract_cmip6(
     output_dir: str,
     queue: str,
     overwrite: bool,
+    dry_run: bool,
 ) -> None:
     """Extract CMIP6 data.
 
@@ -139,7 +142,7 @@ def extract_cmip6(
     """
     overwrite_arg = {"overwrite": None} if overwrite else {}
 
-    jobmon.run_parallel(
+    run_parallel_maybe_dry_run(
         runner="cdtask",
         task_name="extract cmip6",
         node_args={
@@ -160,4 +163,5 @@ def extract_cmip6(
         },
         max_attempts=1,
         concurrency_limit=50,
+        dry_run=dry_run,
     )

--- a/src/climate_data/extract/elevation.py
+++ b/src/climate_data/extract/elevation.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import click
 import requests
 import tqdm
-from rra_tools import jobmon
 
 from climate_data import (
     cli_options as clio,
@@ -12,6 +11,7 @@ from climate_data import (
     constants as cdc,
 )
 from climate_data.data import ClimateData
+from climate_data.jobmon_utils import run_parallel_maybe_dry_run
 
 API_ENDPOINT = "https://portal.opentopography.org/API/globaldem"
 
@@ -105,10 +105,12 @@ def extract_elevation_task(
 )
 @clio.with_output_directory(cdc.MODEL_ROOT)
 @clio.with_queue()
+@clio.with_dry_run()
 def extract_elevation(
     model_name: str,
     output_dir: str,
     queue: str,
+    dry_run: bool,
 ) -> None:
     """Download elevation data from Open Topography."""
     invalid = True
@@ -119,7 +121,7 @@ def extract_elevation(
     lat_starts = list(range(-90, 90, FETCH_SIZE))
     lon_starts = list(range(-180, 180, FETCH_SIZE))
 
-    jobmon.run_parallel(
+    run_parallel_maybe_dry_run(
         runner="cdtask",
         task_name="extract elevation",
         node_args={
@@ -137,4 +139,5 @@ def extract_elevation(
             "runtime": "240m",
             "project": "proj_rapidresponse",
         },
+        dry_run=dry_run,
     )

--- a/src/climate_data/extract/era5.py
+++ b/src/climate_data/extract/era5.py
@@ -12,7 +12,6 @@ import cdsapi
 import click
 import xarray as xr
 import yaml
-from rra_tools import jobmon
 from rra_tools.shell_tools import touch
 
 from climate_data import (
@@ -22,6 +21,7 @@ from climate_data import (
     constants as cdc,
 )
 from climate_data.data import ClimateData
+from climate_data.jobmon_utils import run_parallel_maybe_dry_run
 
 _NETCDF_VALID_ENCODINGS = {
     "zlib",
@@ -290,6 +290,7 @@ def build_task_lists(
 @clio.with_year(years=cdc.HISTORY_YEARS, allow_all=True)
 @clio.with_output_directory(cdc.MODEL_ROOT)
 @clio.with_queue()
+@clio.with_dry_run()
 def extract_era5(
     era5_dataset: list[str],
     era5_variable: list[str],
@@ -297,6 +298,7 @@ def extract_era5(
     month: list[str],
     output_dir: str,
     queue: str,
+    dry_run: bool,
 ) -> None:
     cdata = ClimateData(output_dir)
     cred_path = cdata.credentials_root / "copernicus.yaml"
@@ -335,7 +337,7 @@ def extract_era5(
             "jobs",
         )
 
-        status = jobmon.run_parallel(
+        status = run_parallel_maybe_dry_run(
             runner="cdtask",
             task_name="extract era5_download",
             flat_node_args=(
@@ -353,6 +355,7 @@ def extract_era5(
                 "project": "proj_rapidresponse",
             },
             max_attempts=1,
+            dry_run=dry_run,
         )
         download_statuses.append(status)
 
@@ -360,7 +363,7 @@ def extract_era5(
         print("No datasets to compress.")
         return
 
-    compress_status = jobmon.run_parallel(
+    compress_status = run_parallel_maybe_dry_run(
         runner="cdtask",
         task_name="extract era5_compress",
         flat_node_args=(
@@ -378,6 +381,7 @@ def extract_era5(
             "project": "proj_rapidresponse",
         },
         max_attempts=1,
+        dry_run=dry_run,
     )
 
     if any(s != "D" for s in download_statuses):

--- a/src/climate_data/extract/ncei_climate_stations.py
+++ b/src/climate_data/extract/ncei_climate_stations.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import click
 import pandas as pd
-from rra_tools import jobmon
 from rra_tools.shell_tools import mkdir, wget
 
 from climate_data import (
@@ -13,6 +12,7 @@ from climate_data import (
     constants as cdc,
 )
 from climate_data.data import ClimateData
+from climate_data.jobmon_utils import run_parallel_maybe_dry_run
 
 URL_TEMPLATE = (
     "https://www.ncei.noaa.gov/data/global-summary-of-the-day/archive/{year}.tar.gz"
@@ -50,8 +50,13 @@ def extract_ncei_climate_stations_task(year: str, output_dir: str) -> None:
 @click.command()
 @clio.with_output_directory(cdc.MODEL_ROOT)
 @clio.with_queue()
-def extract_ncei_climate_stations(output_dir: str, queue: str) -> None:
-    jobmon.run_parallel(
+@clio.with_dry_run()
+def extract_ncei_climate_stations(
+    output_dir: str,
+    queue: str,
+    dry_run: bool,
+) -> None:
+    run_parallel_maybe_dry_run(
         runner="cdtask",
         task_name="extract ncei",
         node_args={
@@ -67,4 +72,5 @@ def extract_ncei_climate_stations(output_dir: str, queue: str) -> None:
             "runtime": "240m",
             "project": "proj_rapidresponse",
         },
+        dry_run=dry_run,
     )

--- a/src/climate_data/generate/draws.py
+++ b/src/climate_data/generate/draws.py
@@ -5,12 +5,12 @@ import click
 import numpy as np
 import tqdm
 import xarray as xr
-from rra_tools import jobmon
 
 from climate_data import cli_options as clio
 from climate_data import constants as cdc
 from climate_data.data import ClimateData
 from climate_data.generate.scenario_annual import TRANSFORM_MAP
+from climate_data.jobmon_utils import run_parallel_maybe_dry_run
 
 
 def compile_gcm_main(
@@ -115,12 +115,14 @@ def compile_gcm_task(
 @clio.with_output_directory(cdc.MODEL_ROOT)
 @clio.with_overwrite()
 @clio.with_queue()
+@clio.with_dry_run()
 def draws(
     target_variable: list[str],
     cmip6_experiment: list[str],
     output_dir: str,
     overwrite: bool,
     queue: str,
+    dry_run: bool,
 ) -> None:
     cdata = ClimateData(output_dir)
 
@@ -140,7 +142,7 @@ def draws(
 
     print(f"{len(to_run)} GCM-members to compile.")
 
-    status = jobmon.run_parallel(
+    status = run_parallel_maybe_dry_run(
         runner="cdtask",
         task_name="generate compile_gcm",
         flat_node_args=(
@@ -158,6 +160,7 @@ def draws(
             "project": "proj_rapidresponse",
         },
         max_attempts=1,
+        dry_run=dry_run,
     )
 
     if status != "D":

--- a/src/climate_data/generate/historical_daily.py
+++ b/src/climate_data/generate/historical_daily.py
@@ -5,7 +5,6 @@ import click
 import dask
 import pandas as pd
 import xarray as xr
-from rra_tools import jobmon
 
 from climate_data import (
     cli_options as clio,
@@ -15,6 +14,7 @@ from climate_data import (
 )
 from climate_data.data import ClimateData
 from climate_data.generate import utils
+from climate_data.jobmon_utils import run_parallel_maybe_dry_run
 
 # Map from source variable to a unit conversion function
 CONVERT_MAP = {
@@ -262,12 +262,14 @@ def generate_historical_daily_task(
 @clio.with_output_directory(cdc.MODEL_ROOT)
 @clio.with_queue()
 @clio.with_overwrite()
+@clio.with_dry_run()
 def generate_historical_daily(
     target_variable: list[str],
     year: list[str],
     output_dir: str,
     queue: str,
     overwrite: bool,
+    dry_run: bool,
 ) -> None:
     cdata = ClimateData(output_dir)
 
@@ -285,7 +287,7 @@ def generate_historical_daily(
         f"Launching {len(years_and_variables)} tasks"
     )
 
-    jobmon.run_parallel(
+    run_parallel_maybe_dry_run(
         runner="cdtask",
         task_name="generate historical_daily",
         flat_node_args=(
@@ -303,4 +305,5 @@ def generate_historical_daily(
             "project": "proj_rapidresponse",
         },
         max_attempts=2,
+        dry_run=dry_run,
     )

--- a/src/climate_data/generate/historical_reference.py
+++ b/src/climate_data/generate/historical_reference.py
@@ -1,6 +1,5 @@
 import click
 import xarray as xr
-from rra_tools import jobmon
 
 from climate_data import (
     cli_options as clio,
@@ -12,6 +11,7 @@ from climate_data.data import ClimateData
 from climate_data.generate.historical_daily import (
     TRANSFORM_MAP,
 )
+from climate_data.jobmon_utils import run_parallel_maybe_dry_run
 
 
 def generate_historical_reference_main(
@@ -65,12 +65,14 @@ def generate_historical_reference_task(
 @clio.with_target_variable(TRANSFORM_MAP, allow_all=True)
 @clio.with_output_directory(cdc.MODEL_ROOT)
 @clio.with_queue()
+@clio.with_dry_run()
 def generate_historical_reference(
     target_variable: list[str],
     output_dir: str,
     queue: str,
+    dry_run: bool,
 ) -> None:
-    jobmon.run_parallel(
+    run_parallel_maybe_dry_run(
         runner="cdtask",
         task_name="generate historical_reference",
         node_args={
@@ -87,4 +89,5 @@ def generate_historical_reference(
             "project": "proj_rapidresponse",
         },
         max_attempts=1,
+        dry_run=dry_run,
     )

--- a/src/climate_data/generate/scenario_annual.py
+++ b/src/climate_data/generate/scenario_annual.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import click
 import xarray as xr
 from dask.diagnostics.progress import ProgressBar
-from rra_tools import jobmon
 
 from climate_data import (
     cli_options as clio,
@@ -20,6 +19,7 @@ from climate_data.generate.scenario_daily import (
 from climate_data.generate.scenario_daily import (
     generate_scenario_daily_main,
 )
+from climate_data.jobmon_utils import run_parallel_maybe_dry_run
 
 TEMP_THRESHOLDS = [30]
 
@@ -220,12 +220,14 @@ def build_arg_list(
 @clio.with_output_directory(cdc.MODEL_ROOT)
 @clio.with_queue()
 @clio.with_overwrite()
+@clio.with_dry_run()
 def generate_scenario_annual(
     target_variable: list[str],
     scenario: list[str],
     output_dir: str,
     queue: str,
     overwrite: bool,
+    dry_run: bool,
 ) -> None:
     to_run, complete = build_arg_list(
         target_variable,
@@ -238,7 +240,7 @@ def generate_scenario_annual(
 
     if not to_run:
         return
-    jobmon.run_parallel(
+    run_parallel_maybe_dry_run(
         runner="cdtask",
         task_name="generate scenario_annual",
         flat_node_args=(
@@ -256,4 +258,5 @@ def generate_scenario_annual(
             "project": "proj_rapidresponse",
         },
         max_attempts=1,
+        dry_run=dry_run,
     )

--- a/src/climate_data/generate/scenario_daily.py
+++ b/src/climate_data/generate/scenario_daily.py
@@ -5,7 +5,6 @@ import click
 import numpy as np
 import pandas as pd
 import xarray as xr
-from rra_tools import jobmon
 
 from climate_data import (
     cli_options as clio,
@@ -15,6 +14,7 @@ from climate_data import (
 )
 from climate_data.data import ClimateData
 from climate_data.generate import utils
+from climate_data.jobmon_utils import run_parallel_maybe_dry_run
 
 # Map from source variable to a unit conversion function
 CONVERT_MAP = {
@@ -242,6 +242,7 @@ def generate_scenario_daily_task(
 @clio.with_output_directory(cdc.MODEL_ROOT)
 @clio.with_queue()
 @clio.with_overwrite()
+@clio.with_dry_run()
 def generate_scenario_daily(
     target_variable: list[str],
     cmip6_experiment: list[str],
@@ -249,6 +250,7 @@ def generate_scenario_daily(
     output_dir: str,
     queue: str,
     overwrite: bool,
+    dry_run: bool,
 ) -> None:
     cdata = ClimateData(output_dir)
     veyg = []
@@ -267,7 +269,7 @@ def generate_scenario_daily(
         return
 
     print(f"{len(complete)} tasks already done. Launching {len(veyg)} tasks")
-    jobmon.run_parallel(
+    run_parallel_maybe_dry_run(
         runner="cdtask",
         task_name="generate scenario_daily",
         flat_node_args=(
@@ -285,4 +287,5 @@ def generate_scenario_daily(
             "project": "proj_rapidresponse",
         },
         max_attempts=2,
+        dry_run=dry_run,
     )

--- a/src/climate_data/jobmon_utils.py
+++ b/src/climate_data/jobmon_utils.py
@@ -1,0 +1,221 @@
+"""
+Helpers for working with jobmon in the Climate Data CLI.
+
+The main entrypoint is ``run_parallel_maybe_dry_run`` which mirrors
+``rra_tools.jobmon.run_parallel`` but adds a ``dry_run`` flag.
+
+When ``dry_run`` is ``True``, this helper:
+* Expands ``flat_node_args`` or ``node_args`` into per-job CLI argument sets.
+* Builds sbatch-like preview commands using the supplied task resources.
+* Prints a short summary plus representative example commands.
+* Returns a dummy success status without touching jobmon or the scheduler.
+
+When ``dry_run`` is ``False``, it simply delegates to
+``jobmon.run_parallel`` with identical semantics.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from rra_tools import jobmon
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from pathlib import Path
+
+_MAX_EXAMPLE_JOBS = 10
+
+
+def _normalize_task_args(task_args: Mapping[str, Any] | None) -> dict[str, Any]:
+    return dict(task_args or {})
+
+
+def _iter_jobs_from_flat_node_args(
+    flat_node_args: tuple[Sequence[str], Sequence[Sequence[Any]]],
+) -> list[dict[str, Any]]:
+    keys, rows = flat_node_args
+    jobs: list[dict[str, Any]] = []
+    for row in rows:
+        jobs.append(dict(zip(keys, row, strict=False)))
+    return jobs
+
+
+def _iter_jobs_from_node_args(
+    node_args: Mapping[str, Sequence[Any]],
+) -> list[dict[str, Any]]:
+    import itertools
+
+    # jobmon treats ``node_args`` as a cartesian product over the sequences.
+    items = list(node_args.items())
+    if not items:
+        return []
+
+    keys = [k for k, _ in items]
+    value_lists = [list(vs) for _, vs in items]
+
+    jobs: list[dict[str, Any]] = []
+    for combo in itertools.product(*value_lists):
+        jobs.append(dict(zip(keys, combo, strict=False)))
+    return jobs
+
+
+def _format_cli_args(args: Mapping[str, Any]) -> str:
+    parts: list[str] = []
+    for key, value in args.items():
+        flag = f"--{key}"
+        if isinstance(value, bool):
+            if value:
+                parts.append(flag)
+            continue
+        if isinstance(value, list | tuple | set):
+            for v in value:
+                parts.append(f"{flag} {v}")
+            continue
+        parts.append(f"{flag} {value}")
+    return " ".join(parts)
+
+
+def _format_sbatch_like_line(
+    *,
+    runner: str,
+    task_name: str,
+    job_args: Mapping[str, Any],
+    task_args: Mapping[str, Any],
+    task_resources: Mapping[str, Any],
+) -> str:
+    base_cmd_parts = [runner, task_name]
+    cli_for_job = _format_cli_args(job_args)
+    cli_for_task = _format_cli_args(task_args)
+    for segment in (cli_for_job, cli_for_task):
+        if segment:
+            base_cmd_parts.append(segment)
+    command = " ".join(base_cmd_parts)
+
+    # Escape any embedded double quotes for the wrap.
+    command = command.replace('"', r"\"")
+
+    queue = task_resources.get("queue", "")
+    cores = task_resources.get("cores", "")
+    memory = task_resources.get("memory", "")
+    runtime = task_resources.get("runtime", "")
+    project = task_resources.get("project", "")
+
+    sbatch_parts = ["sbatch"]
+    if queue:
+        sbatch_parts.append(f"--partition={queue}")
+    if cores:
+        sbatch_parts.append(f"--cpus-per-task={cores}")
+    if memory:
+        sbatch_parts.append(f"--mem={memory}")
+    if runtime:
+        sbatch_parts.append(f"--time={runtime}")
+    if project:
+        sbatch_parts.append(f"--account={project}")
+    sbatch_parts.append(f'--wrap="{command}"')
+
+    return " ".join(sbatch_parts)
+
+
+def run_parallel_maybe_dry_run(
+    *,
+    runner: str,
+    task_name: str,
+    task_resources: Mapping[str, Any],
+    flat_node_args: tuple[Sequence[str], Sequence[Sequence[Any]]] | None = None,
+    node_args: Mapping[str, Sequence[Any]] | None = None,
+    task_args: Mapping[str, Any] | None = None,
+    log_root: str | Path | None = None,
+    max_attempts: int | None = None,
+    concurrency_limit: int | None = None,
+    dry_run: bool,
+) -> Any:
+    """Wrapper around ``jobmon.run_parallel`` with optional dry-run behavior.
+
+    Parameters
+    ----------
+    runner
+        The executable used for tasks, e.g. ``"cdtask"`` or ``"cdtask aggregate"``.
+    task_name
+        A short, human-readable name for the job group.
+    task_resources
+        Resource profile for the tasks (queue, cores, memory, runtime, project, ...).
+    flat_node_args
+        Tuple of (argument names, rows) describing per-node CLI arguments.
+    node_args
+        Mapping from argument name to a sequence of values; all combinations are used.
+    task_args
+        Shared CLI arguments that are the same for all nodes.
+    log_root
+        Optional log directory passed through to jobmon.
+    max_attempts
+        Maximum number of attempts; passed through to jobmon. Defaults to ``None``
+        to match ``jobmon.run_parallel`` (jobmon then applies its own default).
+    dry_run
+        If ``True``, only print sbatch-like previews instead of submitting.
+    """
+    if not dry_run:
+        kwargs: dict[str, Any] = {
+            "runner": runner,
+            "task_name": task_name,
+            "flat_node_args": flat_node_args,
+            "node_args": node_args,
+            "task_args": task_args,
+            "task_resources": task_resources,
+            "log_root": log_root,
+            "max_attempts": max_attempts,
+        }
+        if concurrency_limit is not None:
+            kwargs["concurrency_limit"] = concurrency_limit
+        return jobmon.run_parallel(**kwargs)
+
+    normalized_task_args = _normalize_task_args(task_args)
+
+    jobs: list[dict[str, Any]] = []
+    if flat_node_args is not None:
+        jobs = _iter_jobs_from_flat_node_args(flat_node_args)
+    elif node_args is not None:
+        jobs = _iter_jobs_from_node_args(node_args)
+    else:
+        jobs = [{}]
+
+    n_jobs = len(jobs)
+    queue = task_resources.get("queue", "")
+    cores = task_resources.get("cores", "")
+    memory = task_resources.get("memory", "")
+    runtime = task_resources.get("runtime", "")
+    project = task_resources.get("project", "")
+
+    print(
+        "[DRY-RUN] "
+        f"Would submit {n_jobs} job{'s' if n_jobs != 1 else ''} "
+        f"for task '{task_name}' via runner '{runner}'."
+    )
+    print("  Resources:")
+    print(f"    queue   = {queue}")
+    print(f"    cores   = {cores}")
+    print(f"    memory  = {memory}")
+    print(f"    runtime = {runtime}")
+    print(f"    project = {project}")
+
+    n_examples = min(n_jobs, _MAX_EXAMPLE_JOBS)
+    if n_examples > 0:
+        print(f"  Example sbatch-like commands (showing {n_examples} of {n_jobs}):")
+        for job in jobs[:n_examples]:
+            line = _format_sbatch_like_line(
+                runner=runner,
+                task_name=task_name,
+                job_args=job,
+                task_args=normalized_task_args,
+                task_resources=task_resources,
+            )
+            print("   ", line)
+        if n_jobs > n_examples:
+            print(
+                f"  ... ({n_jobs - n_examples} more job"
+                f"{'s' if n_jobs - n_examples != 1 else ''} not shown)"
+            )
+
+    # Return a dummy "success" status so callers that expect a jobmon status
+    # code continue without raising errors.
+    return "D"

--- a/src/climate_data/special/compile_person_days.py
+++ b/src/climate_data/special/compile_person_days.py
@@ -1,7 +1,6 @@
 import click
 import pandas as pd
 import tqdm
-from rra_tools import jobmon
 from rra_tools.shell_tools import mkdir
 
 from climate_data import cli_options as clio
@@ -12,6 +11,7 @@ from climate_data.data import (
     PopulationModelData,
     save_parquet,
 )
+from climate_data.jobmon_utils import run_parallel_maybe_dry_run
 from climate_data.special import utils
 
 HIERARCHY = "gbd_2021"
@@ -121,12 +121,14 @@ def compile_person_days_task(
 @clio.with_input_directory("population-model", cdc.POPULATION_MODEL_ROOT)
 @clio.with_output_directory(cdc.AGGREGATE_ROOT)
 @clio.with_queue()
+@clio.with_dry_run()
 def compile_person_days(
     cmip6_experiment: list[str],
     climate_data_dir: str,
     population_model_dir: str,
     output_dir: str,
     queue: str,
+    dry_run: bool,
 ) -> None:
     ca_data = ClimateAggregateData(output_dir)
     cd_data = ClimateData(climate_data_dir, read_only=True)
@@ -134,7 +136,7 @@ def compile_person_days(
 
     print(f"Running {len(cmip6_experiment) * len(gcm_members)} jobs")
 
-    jobmon.run_parallel(
+    run_parallel_maybe_dry_run(
         runner="cdtask special",
         task_name="compile_person_days",
         node_args={
@@ -154,6 +156,7 @@ def compile_person_days(
         },
         log_root=ca_data.log_dir("compile_person_days"),
         max_attempts=3,
+        dry_run=dry_run,
     )
 
     # results_version = "2026_01_12"

--- a/src/climate_data/special/temperature_person_days.py
+++ b/src/climate_data/special/temperature_person_days.py
@@ -4,7 +4,6 @@ import click
 import numpy as np
 import pandas as pd
 import tqdm
-from rra_tools import jobmon
 from rra_tools.shell_tools import mkdir
 
 from climate_data import cli_options as clio
@@ -15,6 +14,7 @@ from climate_data.data import (
     PopulationModelData,
     save_parquet,
 )
+from climate_data.jobmon_utils import run_parallel_maybe_dry_run
 from climate_data.special import utils
 
 HIERARCHY = "gbd_2023"
@@ -150,6 +150,7 @@ def temperature_person_days_task(
 @clio.with_input_directory("climate-data", cdc.MODEL_ROOT)
 @clio.with_output_directory(cdc.AGGREGATE_ROOT)
 @clio.with_queue()
+@clio.with_dry_run()
 def temperature_person_days(
     block_key: str,
     cmip6_experiment: list[str],
@@ -157,6 +158,7 @@ def temperature_person_days(
     climate_data_dir: str,
     output_dir: str,
     queue: str,
+    dry_run: bool,
 ) -> None:
     ca_data = ClimateAggregateData(output_dir)
     cd_data = ClimateData(climate_data_dir, read_only=True)
@@ -188,7 +190,7 @@ def temperature_person_days(
 
     print(f"Running {len(jobs)} jobs")
 
-    jobmon.run_parallel(
+    run_parallel_maybe_dry_run(
         runner="cdtask special",
         task_name="temperature_person_days",
         flat_node_args=(
@@ -209,4 +211,5 @@ def temperature_person_days(
         },
         log_root=ca_data.log_dir("temperature_person_days"),
         max_attempts=3,
+        dry_run=dry_run,
     )

--- a/src/climate_data/special/temperature_zone.py
+++ b/src/climate_data/special/temperature_zone.py
@@ -2,7 +2,6 @@ import itertools
 from pathlib import Path
 
 import click
-from rra_tools import jobmon
 
 from climate_data import (
     cli_options as clio,
@@ -11,6 +10,7 @@ from climate_data import (
     constants as cdc,
 )
 from climate_data.data import ClimateData
+from climate_data.jobmon_utils import run_parallel_maybe_dry_run
 
 
 def generate_temperature_zone_main(
@@ -62,11 +62,13 @@ def generate_temperature_zone_task(
 @clio.with_output_directory(cdc.MODEL_ROOT)
 @clio.with_queue()
 @clio.with_overwrite()
+@clio.with_dry_run()
 def generate_temperature_zone(
     cmip6_experiment: list[str],
     output_dir: str,
     queue: str,
     overwrite: bool,
+    dry_run: bool,
 ) -> None:
     cdata = ClimateData(output_dir)
     gcm_members = cdata.list_gcm_members("ssp126", "mean_temperature")
@@ -82,7 +84,7 @@ def generate_temperature_zone(
 
     print(f"{len(complete)} tasks already done. Launching {len(to_run)} tasks")
 
-    jobmon.run_parallel(
+    run_parallel_maybe_dry_run(
         runner="cdtask special",
         task_name="temperature_zone",
         flat_node_args=(
@@ -100,4 +102,5 @@ def generate_temperature_zone(
             "project": "proj_rapidresponse",
         },
         max_attempts=2,
+        dry_run=dry_run,
     )


### PR DESCRIPTION
Implements CLIMATE-21. Adds a dry-run mode so runners can be previewed without
scheduling cluster jobs.

## What
- New `jobmon_utils.run_parallel_maybe_dry_run` — a drop-in wrapper around
  `rra_tools.jobmon.run_parallel` that, with `dry_run=True`, prints sbatch-like
  per-job previews and returns a dummy `"D"` status instead of submitting.
- New `clio.with_dry_run()` option (`--dry-run/--no-dry-run`), threaded through
  the runners across `extract/`, `generate/`, `downscale/`, `aggregate/`,
  `diagnostics/`, and `special/`.

## Notes
- `max_attempts` defaults to `None` to match `jobmon.run_parallel` (no silent
  no-retry behavior).
- Pure infra: no storage-root or year-range changes (those are in CLIMATE-22).

🤖 Generated with [Claude Code]