### PR TITLE
ci: move workflows off the departed maintainer's personal token

### DIFF
--- a/.github/alternative_workflows/build_docs.yml
+++ b/.github/alternative_workflows/build_docs.yml
@@ -10,12 +10,12 @@ on:
 
 jobs:
   build-and-deploy-docs:
-    if: ${{ github.event.pull_request.merged }} or ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event.pull_request.merged || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # mkdocs gh-deploy pushes the gh-pages branch (built-in GITHUB_TOKEN)
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_TOKEN }}
       - uses: ./.github/actions/python-poetry-env
       - name: Deploy docs
         run: poetry run mkdocs gh-deploy --force

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -10,12 +10,12 @@ on:
 
 jobs:
   build-and-deploy-docs:
-    if: ${{ github.event.pull_request.merged }} or ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event.pull_request.merged || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # mkdocs gh-deploy pushes the gh-pages branch (built-in GITHUB_TOKEN)
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_TOKEN }}
       - uses: ./.github/actions/python-poetry-env
       - name: Deploy docs
         run: poetry run mkdocs gh-deploy --force

--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -1,12 +1,25 @@
+# RETIRED 21Jul2026 (see CLIMATE-24). This workflow runs `cruft update` to sync the repo with
+# its cookiecutter template. It previously used a personal PAT (secrets.GH_TOKEN) owned by a
+# maintainer who has left IHME; when that token became invalid the workflow stopped working.
+# It now uses the built-in GITHUB_TOKEN (no PAT), which CANNOT create/update files under
+# .github/workflows/** and whose PRs do not trigger CI -- so template-sync no longer functions
+# and the daily `schedule:` trigger has been removed (workflow_dispatch only).
+#
+# TO REVIVE (CLIMATE-24): provision a NON-personal credential -- an org secret or a GitHub App
+# installation token, NOT a personal PAT (a personal PAT re-creates the "dies when the owner
+# leaves" failure) -- scoped contents:write, pull-requests:write, workflows:write. Store it as
+# e.g. secrets.CRUFT_TOKEN, point the env/token in the "Create Pull Request" step at it, and
+# re-add the `schedule:` trigger below.
 name: Autoupdate project structure
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * *"  # at the end of every day
 
 jobs:
   auto-update-project:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -73,8 +86,9 @@ jobs:
       # behaviour if PR already exists: https://github.com/marketplace/actions/create-pull-request#action-behaviour
       - name: Create Pull Request
         env:
-          # a PAT is required to be able to update workflows
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          # Built-in token (no PAT). NOTE: cannot create/update workflow files, so cruft
+          # updates that touch .github/workflows/** will fail here. See CLIMATE-24 to revive.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ steps.changes.outputs.changed > 0 && env.GITHUB_TOKEN != 0 }}
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   auto-update-dependencies:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/python-poetry-env
@@ -56,7 +59,8 @@ jobs:
       # behaviour if PR already exists: https://github.com/marketplace/actions/create-pull-request#action-behaviour
       - name: Create Pull Request
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          # Built-in token: opens the PR but does NOT trigger CI on it (re-run manually).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ steps.check_for_outdated_dependencies.outputs.body != 0 && env.GITHUB_TOKEN != 0 }}
         uses: peter-evans/create-pull-request@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Extended `HISTORY_YEARS` through 2025; `draws` now prefers historical ERA5 over
   scenario data for overlapping years. (CLIMATE-22)
 - Moved the storage root (`MODEL_ROOT`) to `/mnt/share/geospatial/climate/`. (CLIMATE-22)
+- Moved CI workflows off a departed maintainer's personal `GH_TOKEN` to the built-in
+  `GITHUB_TOKEN`. Auto dependency-bump PRs no longer trigger CI, and the cookiecutter
+  template-sync workflow is retired (daily schedule removed); reviving it needs a
+  non-personal token. (CLIMATE-24)
 ### Fixed
 - person-days: zero-fill gridded-population nodata (NaN) before `compute_person_days`,
   so NaN pixels no longer poison output cells and zero out small/coastal locations
@@ -30,3 +34,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   `Path.exists()` misuse (positional arg → `TypeError`) had masked that it was a
   no-op: the parallel workers already write every page, and its one live branch
   regenerated figures with `write=False` and discarded them.
+- Docs deployment: `build_docs` now authenticates with the built-in `GITHUB_TOKEN`
+  (+ `contents: write`) instead of a dead personal token, so `mkdocs gh-deploy` can push
+  `gh-pages` again; also fixed a malformed job `if:` expression. (CLIMATE-24)


### PR DESCRIPTION
**What:** Move all CI workflows off `secrets.GH_TOKEN` (a personal token owned by a maintainer who left IHME) to the built-in `GITHUB_TOKEN`, with explicit least-privilege `permissions:`.

**Why:** `build_docs`'s "Deploy docs" step (`mkdocs gh-deploy`) fails on every merge because the dead personal token can't push `gh-pages`. The same token also gated `dependencies.yml` and `cookiecutter.yml`.

**Changes**
- `build_docs.yml`: drop the checkout `token:`, add `permissions: contents: write`; fix a malformed job `if:` (`}} or {{` → single `||`).
- `alternative_workflows/build_docs.yml`: same swap (inert — not under `.github/workflows/`; consistency only).
- `dependencies.yml`: → `GITHUB_TOKEN` + permissions. Monthly auto PR still opens but won't auto-trigger CI (re-run manually).
- `cookiecutter.yml`: → `GITHUB_TOKEN` + permissions; daily `schedule:` removed; template-sync retired (`GITHUB_TOKEN` can't open workflow-editing PRs) with a revival recipe in a top-of-file comment.

**Consequences (accepted):** docs deploy fixed; dependency auto-PRs lose auto-CI; cookiecutter template-sync retired — revival tracked in **CLIMATE-24** (needs a non-personal org/App token).

**Verification:** local YAML parse + `pre-commit`/`kacl` clean; CI `actionlint` validates the fixed `if:`. Docs deploy is only exercisable on GitHub — will confirm via a `workflow_dispatch` `build_docs` run after merge.

Supersedes #36 (its token-swap intent; #36's stale src edits are already on `main` via #41/#42). Relates to #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)