### PR TITLE
CLIMATE-21: aggregate — skip blocks with no shapefile intersection (incorporates #37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 ### Added
+- aggregate: skip modeling-frame blocks that don't intersect the hierarchy's raking
+  shapes — they contribute only empty results, so the `pixel` and `hierarchy` stages
+  skip them (fewer jobs; e.g. `lsae_1285` 52,800 vs 78,400). Fails loudly if the
+  filter would drop every block. (#37)
 - Dry-run preview for cluster runners: `jobmon_utils.run_parallel_maybe_dry_run`
   and a `--dry-run/--no-dry-run` option (`clio.with_dry_run`) threaded through the
   runners; prints sbatch-like job previews instead of submitting. (CLIMATE-21)

--- a/src/climate_data/aggregate/hierarchy.py
+++ b/src/climate_data/aggregate/hierarchy.py
@@ -66,6 +66,8 @@ def hierarchy_main(
     # Get all block keys
     modeling_frame = pm_data.load_modeling_frame()
     block_keys = modeling_frame.block_key.unique()
+    intersecting = utils.blocks_with_shapefile_intersections(hierarchy, pm_data)
+    block_keys = [b for b in block_keys if b in intersecting]
 
     # Load and combine all block-level results
     desc_template = "{draw:5} {block_key:15}"

--- a/src/climate_data/aggregate/hierarchy.py
+++ b/src/climate_data/aggregate/hierarchy.py
@@ -68,7 +68,9 @@ def hierarchy_main(
     # Get all block keys
     modeling_frame = pm_data.load_modeling_frame()
     block_keys = modeling_frame.block_key.unique()
-    intersecting = utils.blocks_with_shapefile_intersections(hierarchy, pm_data)
+    intersecting = utils.blocks_with_shapefile_intersections(
+        hierarchy, pm_data, modeling_frame
+    )
     block_keys = [b for b in block_keys if b in intersecting]
 
     # Load and combine all block-level results

--- a/src/climate_data/aggregate/pixel.py
+++ b/src/climate_data/aggregate/pixel.py
@@ -169,9 +169,19 @@ def pixel(
     block_keys = modeling_frame["block_key"].unique().tolist()
     block_keys = clio.convert_choice(block_key, block_keys)
 
+    print("Computing per-hierarchy block intersection sets")
+    intersecting_by_hier = {
+        h: utils.blocks_with_shapefile_intersections(h, pm_data)
+        for h in hierarchy
+    }
+
+    hbd = []
+    for h in hierarchy:
+        h_blocks = [b for b in block_keys if b in intersecting_by_hier[h]]
+        hbd.extend(itertools.product([h], h_blocks, draw))
+
     print("Checking for existing results")
     jobs = []
-    hbd = list(itertools.product(hierarchy, block_keys, draw))
     for h, b, d in tqdm.tqdm(hbd):
         if not ca_data.raw_results_path(agg_version, h, b, d).exists():
             jobs.append((h, b, d))

--- a/src/climate_data/aggregate/pixel.py
+++ b/src/climate_data/aggregate/pixel.py
@@ -173,13 +173,20 @@ def pixel(
 
     print("Computing per-hierarchy block intersection sets")
     intersecting_by_hier = {
-        h: utils.blocks_with_shapefile_intersections(h, pm_data)
+        h: utils.blocks_with_shapefile_intersections(h, pm_data, modeling_frame)
         for h in hierarchy
     }
 
-    hbd = []
+    hbd: list[tuple[str, str, str]] = []
     for h in hierarchy:
         h_blocks = [b for b in block_keys if b in intersecting_by_hier[h]]
+        if block_key != clio.RUN_ALL:
+            dropped = sorted(set(block_keys) - intersecting_by_hier[h])
+            if dropped:
+                print(
+                    f"{h}: skipping {len(dropped)} explicitly-requested block(s) with "
+                    f"no shapefile intersection: {dropped}"
+                )
         hbd.extend(itertools.product([h], h_blocks, draw))
 
     print("Checking for existing results")

--- a/src/climate_data/aggregate/utils.py
+++ b/src/climate_data/aggregate/utils.py
@@ -212,3 +212,29 @@ def aggregate_climate_to_hierarchy(
     )
     results["value"] = results["weighted_climate"] / results["population"]
     return results
+
+
+def blocks_with_shapefile_intersections(
+    hierarchy: str,
+    pm_data: PopulationModelData,
+) -> set[str]:
+    """Return the set of block_keys whose footprint intersects at least one
+    polygon in the hierarchy's raking shapefile. Blocks not in this set
+    produce empty raw-results (no shape contributes anything), so the
+    pipeline can skip them safely.
+
+    Hierarchy-agnostic: the shapefile lookup is delegated to
+    PopulationModelData.load_raking_shapes, which routes to the right
+    file for whichever hierarchy is in use.
+    """
+    modeling_frame = pm_data.load_modeling_frame()
+    blocks_gdf = (
+        modeling_frame[["block_key", "geometry"]]
+        .dissolve(by="block_key")
+        .reset_index()
+    )
+    shapes = pm_data.load_raking_shapes(hierarchy, bounds=None)
+    if shapes.crs != blocks_gdf.crs:
+        shapes = shapes.to_crs(blocks_gdf.crs)
+    joined = gpd.sjoin(blocks_gdf, shapes, how="inner", predicate="intersects")
+    return set(joined["block_key"].unique())

--- a/src/climate_data/aggregate/utils.py
+++ b/src/climate_data/aggregate/utils.py
@@ -224,24 +224,63 @@ def aggregate_climate_to_hierarchy(
 def blocks_with_shapefile_intersections(
     hierarchy: str,
     pm_data: PopulationModelData,
+    modeling_frame: gpd.GeoDataFrame | None = None,
 ) -> set[str]:
-    """Return the set of block_keys whose footprint intersects at least one
-    polygon in the hierarchy's raking shapefile. Blocks not in this set
-    produce empty raw-results (no shape contributes anything), so the
-    pipeline can skip them safely.
+    """Return the block_keys whose footprint intersects the hierarchy's raking shapes.
 
-    Hierarchy-agnostic: the shapefile lookup is delegated to
-    PopulationModelData.load_raking_shapes, which routes to the right
-    file for whichever hierarchy is in use.
+    Blocks whose (dissolved) modeling-frame geometry intersects no raking polygon
+    contribute only empty rows to the sum/sum aggregation, so the pipeline can skip
+    them. The shapefile lookup is delegated to
+    ``PopulationModelData.load_raking_shapes``, which routes to the right file for
+    whichever hierarchy is in use.
+
+    .. note::
+
+        This uses the block *geometry* vs the full shape set, whereas the production
+        emptiness gate in ``build_location_masks`` uses the raster *bounding box* vs
+        bbox-filtered shapes. Equivalence was validated empirically for ``lsae_1285``
+        (bit-for-bit identical output) but is frame/hierarchy-dependent — re-validate
+        if the modeling frame or a hierarchy's shapes change.
+
+    Parameters
+    ----------
+    hierarchy
+        The full aggregation hierarchy whose raking shapes gate the blocks.
+    pm_data
+        PopulationModelData used to load the raking shapes (and the modeling frame
+        when one is not supplied).
+    modeling_frame
+        Optional pre-loaded modeling frame. Loaded via
+        ``pm_data.load_modeling_frame()`` when ``None``; pass the already-loaded
+        frame to avoid a redundant re-read.
+
+    Returns
+    -------
+    set[str]
+        The block_keys with at least one intersecting raking polygon.
+
+    Raises
+    ------
+    ValueError
+        If no block intersects any raking shape while blocks exist — a likely
+        CRS/shapefile misconfiguration that would otherwise silently skip
+        everything.
     """
-    modeling_frame = pm_data.load_modeling_frame()
+    if modeling_frame is None:
+        modeling_frame = pm_data.load_modeling_frame()
     blocks_gdf = (
-        modeling_frame[["block_key", "geometry"]]
-        .dissolve(by="block_key")
-        .reset_index()
+        modeling_frame[["block_key", "geometry"]].dissolve(by="block_key").reset_index()
     )
-    shapes = pm_data.load_raking_shapes(hierarchy, bounds=None)
+    shapes = pm_data.load_raking_shapes(hierarchy)
     if shapes.crs != blocks_gdf.crs:
         shapes = shapes.to_crs(blocks_gdf.crs)
     joined = gpd.sjoin(blocks_gdf, shapes, how="inner", predicate="intersects")
-    return set(joined["block_key"].unique())
+    intersecting = set(joined["block_key"].unique())
+    if not intersecting and len(blocks_gdf):
+        msg = (
+            f"No blocks intersect the raking shapes for hierarchy '{hierarchy}' "
+            f"({len(blocks_gdf)} blocks checked) — refusing to silently skip every "
+            "block. Check the CRS, the shapefile path, and the sjoin."
+        )
+        raise ValueError(msg)
+    return intersecting

--- a/src/climate_data/data.py
+++ b/src/climate_data/data.py
@@ -138,7 +138,9 @@ class PopulationModelData:
         return self.root / "admin-inputs" / "raking"
 
     def load_raking_shapes(
-        self, full_aggregation_hierarchy: str, bounds: tuple[float, float, float, float]
+        self,
+        full_aggregation_hierarchy: str,
+        bounds: tuple[float, float, float, float] | None = None,
     ) -> gpd.GeoDataFrame:
         """Load shapes for a full aggregation hierarchy within given bounds.
 
@@ -147,7 +149,8 @@ class PopulationModelData:
         full_aggregation_hierarchy
             The full aggregation hierarchy to load (e.g. "gbd_2021")
         bounds
-            The bounds to load (xmin, ymin, xmax, ymax)
+            The bounds to load (xmin, ymin, xmax, ymax). ``None`` (the default)
+            loads all shapes for the hierarchy.
 
         Returns
         -------

--- a/tests/test_aggregate_utils.py
+++ b/tests/test_aggregate_utils.py
@@ -1,0 +1,65 @@
+import geopandas as gpd
+import pytest
+from shapely.geometry import box
+
+from climate_data.aggregate.utils import blocks_with_shapefile_intersections
+from climate_data.data import PopulationModelData
+
+
+def _blocks() -> gpd.GeoDataFrame:
+    """Two blocks: `B-in` near the origin, `B-out` far away."""
+    return gpd.GeoDataFrame(
+        {
+            "block_key": ["B-in", "B-out"],
+            "geometry": [box(0, 0, 1, 1), box(10, 10, 11, 11)],
+        },
+        crs="EPSG:4326",
+    )
+
+
+def test_keeps_only_intersecting_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
+    shapes = gpd.GeoDataFrame(
+        {"location_id": [1], "geometry": [box(0.5, 0.5, 5.0, 5.0)]}, crs="EPSG:4326"
+    )
+    monkeypatch.setattr(
+        PopulationModelData, "load_raking_shapes", lambda *a, **k: shapes
+    )
+
+    result = blocks_with_shapefile_intersections(
+        "gbd_2021", PopulationModelData("unused-root"), _blocks()
+    )
+
+    assert result == {"B-in"}
+
+
+def test_reprojects_mismatched_crs(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Same overlapping shape, but in Web Mercator: the helper must reproject the
+    # shapes to the blocks' CRS before the intersects test.
+    shapes = gpd.GeoDataFrame(
+        {"location_id": [1], "geometry": [box(0.5, 0.5, 5.0, 5.0)]}, crs="EPSG:4326"
+    ).to_crs("EPSG:3857")
+    monkeypatch.setattr(
+        PopulationModelData, "load_raking_shapes", lambda *a, **k: shapes
+    )
+
+    result = blocks_with_shapefile_intersections(
+        "gbd_2021", PopulationModelData("unused-root"), _blocks()
+    )
+
+    assert result == {"B-in"}
+
+
+def test_raises_when_nothing_intersects(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A shape that no block touches: the helper must fail loudly rather than
+    # silently returning an empty set (which would skip every block).
+    shapes = gpd.GeoDataFrame(
+        {"location_id": [1], "geometry": [box(100, 100, 101, 101)]}, crs="EPSG:4326"
+    )
+    monkeypatch.setattr(
+        PopulationModelData, "load_raking_shapes", lambda *a, **k: shapes
+    )
+
+    with pytest.raises(ValueError, match="No blocks intersect"):
+        blocks_with_shapefile_intersections(
+            "gbd_2021", PopulationModelData("unused-root"), _blocks()
+        )


### PR DESCRIPTION
Supersedes and incorporates **#37**. CLIMATE-21.

## Description

Skips `aggregate` pixel blocks whose footprint doesn't intersect any polygon in the
hierarchy's raking shapefile. Those blocks produce empty raw-results today (no admin polygon
→ empty `bounds_map` → zero rows), so not running them is lossless. For `lsae_1285`:
528 of 784 blocks intersect, 256 (32.7%) do not — the pixel workflow drops from 78,400 to
52,800 tasks for a single-hierarchy run.

**The feature is [@bcreiner](https://github.com/bcreiner)'s work.** Rather than
re-authoring it, PR #37 was retargeted onto this branch and merged with a merge commit, so
`1f7ae4f` keeps Bobby's authorship and #37 shows as merged. This branch is therefore:

| commit | author | what |
|---|---|---|
| `1f7ae4f` | Bobby Reiner | the feature — `blocks_with_shapefile_intersections()` in `aggregate/utils.py`, wired into the `pixel` jobmon launcher and `hierarchy_main` |
| `83bf7d2` | Bill Gustafson | merge of #37 into this branch |
| `735cb14` | Bill Gustafson | the review fixes below |

Bobby's skip logic is **unchanged** — same `sjoin`/`intersects` computation, same filtering.

### Review fixes on top (`735cb14`)

From the published review
([review](https://docs.sae.ihme.washington.edu/billg/reviews/feature-block-skip-filter/) ·
[change summary](https://docs.sae.ihme.washington.edu/billg/plans/feature-block-skip-filter-changes/)):

| Category | Change | File |
|---|---|---|
| CI blocker (mypy) | `load_raking_shapes` `bounds` → `tuple[...] \| None = None`; the helper's `bounds=None` call was rejected under strict mypy. Backward-compatible — the only other caller passes a real tuple. | `data.py` |
| CI blocker (mypy) | annotate `hbd: list[tuple[str, str, str]]` | `aggregate/pixel.py` |
| Robustness | the helper now raises `ValueError` if it would drop *every* block while blocks exist — a loud guard against a CRS/shapefile misconfiguration that would otherwise silently produce zero jobs and empty results | `aggregate/utils.py` |
| Perf | helper accepts an optional pre-loaded `modeling_frame`; both call sites pass the frame they already hold, avoiding a redundant per-hierarchy parquet reload | `aggregate/utils.py`, `hierarchy.py`, `pixel.py` |
| UX | `pixel` prints a note when the filter drops an explicitly-requested `--block-key` (previously silent, surprising for targeted runs) | `aggregate/pixel.py` |
| Docs | helper docstring rewritten numpy-style to match its siblings, with an explicit losslessness caveat (below) | `aggregate/utils.py` |
| Tests | new `tests/test_aggregate_utils.py` — keeps only intersecting blocks, reprojects on CRS mismatch, raises when nothing intersects | new file |

The only *runtime* behavior added on top of Bobby's work is the total-empty guard and the
explicit-block-request warning. Everything else is typing, an optional performance argument,
documentation, and tests.

## Downstream impact

None. `results/<hierarchy>/<measure>_<scenario>.parquet` is bit-for-bit unchanged, because
the dropped blocks' contributions were already zero — `hierarchy_main` computes
`sum(weighted_climate) / sum(population)`, and a block contributing `(0, 0)` to a
`(location_id, year_id)` row is identical to it contributing no row.

## Reviewer notes

- **Losslessness caveat**, documented in the docstring: this filter compares block
  *geometry* against the full shape set, whereas the production emptiness gate
  (`build_location_masks`) compares the raster *bounding box* against bbox-filtered shapes.
  Equivalence was validated empirically (bit-for-bit) for `lsae_1285`, but it is
  frame/hierarchy-dependent rather than proven in general.
- **Not exercised end-to-end.** A production dry-run block-count before/after on one
  hierarchy would be the strongest confirmation of the losslessness assumption before this
  is used for a real run.
- `#37`'s failing `pre-commit` check was the strict-mypy `bounds=None` rejection; `735cb14`
  is what fixes it. That check never ran against the fixes, since they lived only on a local
  branch until now.

## Verification

All six CI-equivalent checks green on the tracked tree (43 `.py` files), on top of current
`main` (`fa97841`, i.e. the new lock from #45):

- `ruff format --check` → 43 files already formatted
- `ruff check` → All checks passed
- `mypy` → Success, no issues in 43 source files
- `pytest -q` → 6 passed (3 new + existing)
- `kacl-cli verify` → Success
- `mkdocs build` → exit 0

## Checklist

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
