### PR TITLE
CLIMATE-29: correct the ERA5 precipitation accumulation collapse

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,11 @@ repos:
         types: [ python ]
       - id: mypy
         name: mypy
-        entry: poetry run mypy .
+        # Name the source roots rather than `.`: with pass_filenames: false this hook
+        # walks the whole working tree, so an untracked scratch/ directory fails the
+        # hook locally on errors CI never sees. These three roots cover every tracked
+        # .py file (43 files, same set as `mypy $(git ls-files '*.py')`).
+        entry: poetry run mypy src tests scripts
         require_serial: true
         language: system
         types: [python]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   also reads the first sample of the *next* month — for December, of the next year's
   January — and trims the out-of-month bins the collapse produces at each end. A missing
   look-ahead extract raises rather than silently shortening the final day, so
-  regenerating **2023 requires an ERA5 January 2024 extract**, which does not currently
-  exist. (CLIMATE-29)
+  regenerating **2023 requires an ERA5 January 2024 extract**. One exists in the GBD-2025
+  pull at `/mnt/share/geospatial/climate/extracted_data/era5/` (both datasets, all of 2024
+  and 2025, `expver='0001'` final ERA5). Because that pull came through the newer CDS API
+  it carries `number` and `expver` coordinates and is stored float32 rather than packed
+  int16, so the look-ahead now normalises coordinates before concatenating — `xr.concat`
+  refuses to join datasets whose coordinates differ. (CLIMATE-29)
 - docs: the ERA5 spatial-harmonization section claimed the 0.25° single-level data is
   upsampled with nearest-neighbor interpolation. It is bilinear
   (`generate/historical_daily.py:219`, `:228`); nearest is used only for sea-surface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   template-sync workflow is retired (daily schedule removed); reviving it needs a
   non-personal token. (CLIMATE-24)
 ### Fixed
+- `total_precipitation` was inflated ~1.5-1.6x across the whole historical record.
+  ERA5 stamps an accumulation window by its **end**, so day D's window (forecast steps
+  01-24) has its closing sample timestamped `00:00` of day D+1 — these are interval
+  labels, not instants. The `groupby("time.date")` buckets therefore straddled two
+  windows: each opened with the *previous* day's completed total and never saw its own.
+  Collapsing ERA5-Land with `daily_max` consequently returned `max(yesterday's total,
+  today's 23-hour partial)`. Both ERA5 datasets now collapse with an interval-aware
+  `resample(closed="right", label="left")`, which bins on `(D 00:00, D+1 00:00]` labelled
+  `D` — one whole window per day — via the new `utils.daily_accumulation_last` (ERA5-Land,
+  cumulative) and `utils.daily_accumulation_sum` (single-levels, hourly increments).
+  `last` rather than `max` because the two agree only while the window rises
+  monotonically, which int16 packing does not guarantee. Reported by Anna Rutherford
+  (EOD/WASH). (CLIMATE-29)
 - docs: the ERA5 spatial-harmonization section claimed the 0.25° single-level data is
   upsampled with nearest-neighbor interpolation. It is bilinear
   (`generate/historical_daily.py:219`, `:228`); nearest is used only for sea-surface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   `last` rather than `max` because the two agree only while the window rises
   monotonically, which int16 packing does not guarantee. Reported by Anna Rutherford
   (EOD/WASH). (CLIMATE-29)
+- Because an accumulation window is closed by the following hour, generating a month now
+  also reads the first sample of the *next* month — for December, of the next year's
+  January — and trims the out-of-month bins the collapse produces at each end. A missing
+  look-ahead extract raises rather than silently shortening the final day, so
+  regenerating **2023 requires an ERA5 January 2024 extract**, which does not currently
+  exist. (CLIMATE-29)
 - docs: the ERA5 spatial-harmonization section claimed the 0.25° single-level data is
   upsampled with nearest-neighbor interpolation. It is bilinear
   (`generate/historical_daily.py:219`, `:228`); nearest is used only for sea-surface

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -108,9 +108,18 @@ The historical daily database is constructed from ERA5 data through a series of 
    - Temperature variables are aggregated to daily mean, maximum, and minimum values
    - Wind speed is calculated as the vector magnitude of u and v components
    - Relative humidity is derived from temperature and dewpoint temperature
-   - Precipitation is processed differently for land and single-level datasets:
-     - ERA5-Land: daily maximum (this is a cumulative variable in the land dataset)
-     - ERA5 single-level: daily sum
+   - Precipitation is processed differently for land and single-level datasets. ERA5 stamps
+     an accumulation window by its **end**: day D's window runs forecast steps 01–24, and
+     step 24 carries the timestamp `00:00` of day D+1. These timestamps are interval labels
+     rather than instants, so both datasets are collapsed with an interval-aware resample
+     binning on `(D 00:00, D+1 00:00]` labelled `D` — one whole accumulation window per day,
+     rather than a calendar-day bucket that straddles two. A consequence is that closing a
+     given day requires the following hour, so the final day of each month is read from the
+     next month's file:
+     - ERA5-Land: accumulates since 00Z, so the day's total is the window's **closing
+       sample** (`daily_last`). Taking the maximum instead is only equivalent while the
+       window rises monotonically, which int16 packing does not guarantee.
+     - ERA5 single-level: hourly increments, so the day's total is their **sum**
 
 3. **Spatial harmonization**:
    - ERA5-Land data (0.1° × 0.1°) is left in its native resolution
@@ -188,7 +197,7 @@ The annual variables are produced by aggregating the daily data to annual time s
 
 Each variable is processed with appropriate encoding scales to optimize storage:
 - Temperature variables: 0.01°C precision
-- Precipitation: 10mm precision
+- Precipitation: 0.1mm precision daily, 10mm annual
 - Count-based metrics: Integer values
 
 These annual variables provide a comprehensive set of climate indicators relevant to health impact assessment, capturing both average conditions and extreme events that may influence health outcomes.

--- a/src/climate_data/generate/historical_daily.py
+++ b/src/climate_data/generate/historical_daily.py
@@ -128,6 +128,28 @@ def load_variable(
 LOOKAHEAD_VARIABLES = frozenset({"total_precipitation"})
 
 
+CORE_COORDS = frozenset({"time", "latitude", "longitude"})
+
+
+def drop_noncore_coords(ds: xr.Dataset) -> xr.Dataset:
+    """Drop coordinates the older and newer CDS extract formats disagree about.
+
+    Extracts pulled through the newer CDS API carry `number` (ensemble member) and
+    `expver` ('0001' final ERA5, '0005' preliminary ERA5T) alongside the grid coords;
+    older extracts carry neither, and are packed int16 rather than float32. `xr.concat`
+    refuses to join datasets whose coordinates differ, so a look-ahead that crosses from
+    an old extract into a new one has to be normalised first.
+
+    This is live at the 2023/2024 seam: the 1950-2023 extracts predate the format change
+    and the January 2024 look-ahead comes from the newer GBD-2025 pull.
+    """
+    extra = []
+    for coord in ds.coords:
+        if coord not in CORE_COORDS:
+            extra.append(coord)
+    return ds.drop_vars(extra)
+
+
 def _next_month(year: str, month: int) -> tuple[str, str]:
     """The (year, month) following the one given, rolling December into January."""
     if month == 12:  # noqa: PLR2004
@@ -164,9 +186,9 @@ def load_variable_with_lookahead(
         )
         raise FileNotFoundError(msg)
 
-    ds = load_variable(cdata, variable, year, month, dataset)
-    lookahead = load_variable(cdata, variable, next_year, next_month, dataset).isel(
-        time=[0]
+    ds = drop_noncore_coords(load_variable(cdata, variable, year, month, dataset))
+    lookahead = drop_noncore_coords(
+        load_variable(cdata, variable, next_year, next_month, dataset).isel(time=[0])
     )
     return xr.concat([ds, lookahead], dim="time")
 

--- a/src/climate_data/generate/historical_daily.py
+++ b/src/climate_data/generate/historical_daily.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import click
 import dask
+import numpy as np
 import pandas as pd
 import xarray as xr
 
@@ -121,6 +122,67 @@ def load_variable(
     return ds
 
 
+# Target variables collapsed on hour-ending accumulation windows. Their final day is
+# closed by the next month's first sample, so these need a look-ahead load and a trim.
+# Everything else collapses instantaneous values on calendar days and needs neither.
+LOOKAHEAD_VARIABLES = frozenset({"total_precipitation"})
+
+
+def _next_month(year: str, month: int) -> tuple[str, str]:
+    """The (year, month) following the one given, rolling December into January."""
+    if month == 12:  # noqa: PLR2004
+        return str(int(year) + 1), "01"
+    return year, f"{month + 1:02d}"
+
+
+def load_variable_with_lookahead(
+    cdata: ClimateData,
+    variable: str,
+    year: str,
+    month: str,
+    dataset: str,
+) -> xr.Dataset:
+    """Load a month's hourly data plus the one sample that closes its final day.
+
+    Accumulation windows are stamped by their end, so the last day of a month is closed
+    by the next month's first sample -- for December, by the next *year's* January. That
+    single extra sample completes the final bin without opening a new one.
+
+    Raises if the look-ahead file is absent rather than degrading to the incomplete
+    23-hour window: ERA5 extracts stop at 2023, so regenerating 2023 needs a January
+    2024 file that does not exist, and that should stop the run rather than quietly
+    shorten one day. Checked before loading the target month so the run fails fast.
+    """
+    next_year, next_month = _next_month(year, int(month))
+    lookahead_path = cdata.extracted_era5_path(dataset, variable, next_year, next_month)
+    if not lookahead_path.exists():
+        msg = (
+            f"Cannot close {year}-{month} for {variable}: the accumulation window of its"
+            f" final day ends in the following month, whose extract is missing at"
+            f" {lookahead_path}. Extract {dataset} {variable} {next_year}_{next_month}"
+            f" before generating {year}."
+        )
+        raise FileNotFoundError(msg)
+
+    ds = load_variable(cdata, variable, year, month, dataset)
+    lookahead = load_variable(cdata, variable, next_year, next_month, dataset).isel(
+        time=[0]
+    )
+    return xr.concat([ds, lookahead], dim="time")
+
+
+def trim_to_month(ds: xr.Dataset, year: str, month: int) -> xr.Dataset:
+    """Drop collapsed bins that fall outside the target month.
+
+    The interval-aware collapse labels its first bin with the *previous* month's last
+    day, since that bin holds that day's closing sample. Left in place, every month
+    contributes a duplicate date at its seam.
+    """
+    dates = pd.to_datetime(ds.date.to_index())
+    keep = np.flatnonzero((dates.year == int(year)) & (dates.month == month))
+    return ds.isel(date=keep)
+
+
 def validate_output(ds: xr.Dataset, year: str) -> None:  # noqa: C901
     error_msg_parts = []
 
@@ -171,13 +233,18 @@ def generate_historical_daily_main(
     cdata = ClimateData(output_dir)
 
     transform = TRANSFORM_MAP[target_variable]
+    # Accumulated variables need the next month's first sample to close their final day,
+    # and the resulting out-of-month bins at each end trimmed off afterwards.
+    needs_lookahead = target_variable in LOOKAHEAD_VARIABLES
+    loader = load_variable_with_lookahead if needs_lookahead else load_variable
+
     datasets = []
     for month in range(1, 13):
         month_str = f"{month:02d}"
         print(f"month {month_str}")
         print("    loading single-levels")
         single_level = [
-            load_variable(
+            loader(
                 cdata,
                 sv,
                 year,
@@ -194,6 +261,8 @@ def generate_historical_daily_main(
         ds_single_level = ds_single_level.assign(
             date=pd.to_datetime(ds_single_level.date)
         )
+        if needs_lookahead:
+            ds_single_level = trim_to_month(ds_single_level, year, month)
 
         if target_variable == cdc.ERA5_VARIABLES.sea_surface_temperature:
             print("    interpolating")
@@ -206,7 +275,7 @@ def generate_historical_daily_main(
         else:
             print("    loading land")
             land = [
-                load_variable(
+                loader(
                     cdata, sv, year, month_str, cdc.ERA5_DATASETS.reanalysis_era5_land
                 )
                 for sv in transform.source_variables
@@ -218,6 +287,8 @@ def generate_historical_daily_main(
                     *land, key=cdc.ERA5_DATASETS.reanalysis_era5_land
                 ).compute()
             ds_land = ds_land.assign(date=pd.to_datetime(ds_land.date))
+            if needs_lookahead:
+                ds_land = trim_to_month(ds_land, year, month)
 
             print("    interpolating single level")
             ds_single_level = utils.interpolate_to_target_latlon(

--- a/src/climate_data/generate/historical_daily.py
+++ b/src/climate_data/generate/historical_daily.py
@@ -70,9 +70,15 @@ TRANSFORM_MAP = {
     ),
     "total_precipitation": utils.Transform(
         source_variables=[cdc.ERA5_VARIABLES.total_precipitation],
+        # Precipitation timestamps are hour-ending interval labels, so both branches
+        # collapse with the interval-aware resample rather than a calendar-day groupby.
         transform_funcs={
-            cdc.ERA5_DATASETS.reanalysis_era5_land: [utils.daily_max],
-            cdc.ERA5_DATASETS.reanalysis_era5_single_levels: [utils.daily_sum],
+            # Cumulative since 00Z: the day's total is the window's closing sample.
+            cdc.ERA5_DATASETS.reanalysis_era5_land: [utils.daily_accumulation_last],
+            # Per-hour increments: they sum.
+            cdc.ERA5_DATASETS.reanalysis_era5_single_levels: [
+                utils.daily_accumulation_sum
+            ],
         },
         encoding_scale=0.1,
     ),

--- a/src/climate_data/generate/utils.py
+++ b/src/climate_data/generate/utils.py
@@ -122,6 +122,59 @@ def daily_sum(ds: xr.Dataset) -> xr.Dataset:
     return ds.groupby("time.date").sum()
 
 
+# ERA5 stamps an accumulation window by its END. Day D's window runs forecast steps
+# 01..24, and ECMWF stamps step 24 as 00:00 of day D+1 -- "for the CDS validity time of
+# 00 UTC, the accumulations are over the 24 hours ending at 00 UTC i.e. the accumulation
+# is during the previous day". These timestamps are therefore interval labels, not
+# instants, so a plain `groupby("time.date")` bucket straddles two windows: it opens with
+# day D-1's completed total and never sees day D's.
+#
+# `closed="right"` includes each bin's right edge and excludes its left; `label="left"`
+# names the bin by the day it opens. Together they yield bins (D 00:00, D+1 00:00]
+# labelled D -- exactly one accumulation window per day. Because a day is closed by the
+# following hour, the last day of a month is completed by the next month's first sample.
+ACCUMULATION_FREQ = "1D"
+ACCUMULATION_CLOSED: typing.Literal["right"] = "right"
+ACCUMULATION_LABEL: typing.Literal["left"] = "left"
+
+
+def daily_accumulation_last(ds: xr.Dataset) -> xr.Dataset:
+    """Collapse a within-day cumulative variable to its daily total.
+
+    For ERA5-Land `total_precipitation`, which accumulates since 00Z, the day's total is
+    the window's closing sample, so `last` reads it directly. Prefer this to a maximum:
+    the two agree only while the window rises monotonically, and int16 packing can make
+    it tick down in its final step, in which case the maximum is an earlier,
+    quantisation-inflated sample. Measured over 741,270 land day-pixels, `last` matched
+    the true close for 100.0000% against 99.9864% for `max`.
+
+    Note `resample` emits a regular axis with NaN for empty bins, unlike `groupby`, which
+    emits observed groups only. Callers must trim the partial bins at each end.
+    """
+    resampled = ds.resample(
+        time=ACCUMULATION_FREQ,
+        closed=ACCUMULATION_CLOSED,
+        label=ACCUMULATION_LABEL,
+    ).last()
+    return resampled.rename({"time": "date"})
+
+
+def daily_accumulation_sum(ds: xr.Dataset) -> xr.Dataset:
+    """Collapse a variable of per-hour increments to its daily total.
+
+    For ERA5 single-levels, "accumulations are over the hour ending at the validity
+    date/time", so the increments sum. The same interval convention applies as for
+    `daily_accumulation_last`, so the two stay on a common `date` axis -- they are merged
+    downstream in `generate_historical_daily_main`.
+    """
+    resampled = ds.resample(
+        time=ACCUMULATION_FREQ,
+        closed=ACCUMULATION_CLOSED,
+        label=ACCUMULATION_LABEL,
+    ).sum()
+    return resampled.rename({"time": "date"})
+
+
 def annual_sum(ds: xr.Dataset) -> xr.Dataset:
     return ds.groupby("date.year").sum()
 

--- a/tests/test_generate_utils.py
+++ b/tests/test_generate_utils.py
@@ -1,0 +1,99 @@
+"""Tests for the daily collapse of cumulative ERA5-Land variables (CLIMATE-29)."""
+
+import datetime
+import typing
+
+import numpy as np
+import xarray as xr
+
+from climate_data.generate import utils
+
+# Day 0's completed total, its 23-hour partial, and the same for day 1. The partials sit
+# just under the totals because some rain always falls in the final hour -- that gap is
+# what a bucket ending at hour 23 loses.
+YESTERDAY_TOTAL = 9.0
+DAY0_TOTAL = 2.0
+DAY0_PARTIAL = 1.5
+DAY1_TOTAL = 6.0
+DAY1_PARTIAL = 5.0
+
+DAY0 = datetime.date(2020, 1, 1)
+DAY1 = datetime.date(2020, 1, 2)
+HOURS_PER_DAY = 24
+
+
+def _minimal_hourly_precip() -> xr.Dataset:
+    """Build the smallest cube following the ERA5-Land accumulation convention.
+
+    One pixel, two days. ERA5-Land ``total_precipitation`` accumulates since 00Z, so
+    within a day the value rises; the day's closing total is the step-24 sample, which
+    CDS stamps 00:00 of the *next* day. Hour 00 of a day therefore holds the *previous*
+    day's completed total.
+
+    The cube runs 00:00..23:00 for both days plus one trailing 00:00 sample -- the
+    look-ahead that closes day 1, and which in production lives in the next month's file.
+    """
+    totals = (DAY0_TOTAL, DAY1_TOTAL)
+    partials = (DAY0_PARTIAL, DAY1_PARTIAL)
+    n_time = len(totals) * HOURS_PER_DAY + 1
+    hourly = np.zeros((n_time, 1, 1), dtype="float64")
+
+    for day in range(len(totals)):
+        # Hour 00 holds the previous day's completed total.
+        previous = YESTERDAY_TOTAL if day == 0 else totals[day - 1]
+        hourly[day * HOURS_PER_DAY] = previous
+        # Hours 01..23 rise monotonically to the 23-hour partial.
+        for hour in range(1, HOURS_PER_DAY):
+            hourly[day * HOURS_PER_DAY + hour] = (
+                partials[day] * hour / (HOURS_PER_DAY - 1)
+            )
+    # The look-ahead sample: day 1's closing total.
+    hourly[-1] = totals[-1]
+
+    time = xr.date_range(str(DAY0), periods=n_time, freq="h", use_cftime=False)
+    return xr.Dataset(
+        {"value": (("time", "latitude", "longitude"), hourly)},
+        coords={"time": time, "latitude": [0.0], "longitude": [0.0]},
+    )
+
+
+def _daily_value(collapsed: xr.Dataset, date: datetime.date) -> float:
+    """Pull the single pixel's collapsed value for one date.
+
+    The two collapses label the ``date`` axis differently: ``groupby("time.date")``
+    yields object-dtype ``datetime.date``, while ``resample`` yields ``datetime64``.
+    Match whichever this dataset carries.
+    """
+    key: typing.Any = date
+    if np.issubdtype(collapsed.date.dtype, np.datetime64):
+        key = np.datetime64(date)
+    return float(collapsed.value.sel(date=key).isel(latitude=0, longitude=0))
+
+
+def test_daily_max_returns_previous_day_total() -> None:
+    """Document why ``daily_last`` exists: ``daily_max`` returns yesterday's rain.
+
+    ``groupby("time.date").max()`` buckets hours 00..23, which holds the previous day's
+    completed total (hour 00) and excludes today's (stamped 00:00 tomorrow). Whenever
+    yesterday was wetter than today's partial, the bucket maximum *is* yesterday's total.
+    This is the 1.5-1.6x wet bias in the 1950-2023 historical product.
+    """
+    collapsed = utils.daily_max(_minimal_hourly_precip())
+
+    assert _daily_value(collapsed, DAY0) == YESTERDAY_TOTAL
+    assert _daily_value(collapsed, DAY0) != DAY0_TOTAL
+
+
+def test_daily_accumulation_last_returns_the_closing_sample() -> None:
+    """Treating the timestamps as hour-ending intervals recovers the true daily total.
+
+    ``resample(closed="right", label="left")`` bins on ``(D 00:00, D+1 00:00]`` labelled
+    ``D``, i.e. one whole accumulation window per day. ``last`` rather than ``max``
+    because int16 packing can make the window tick down in its final step, in which case
+    the maximum is an earlier sample -- exact for 100% of real land day-pixels measured,
+    against 99.9864% for max.
+    """
+    collapsed = utils.daily_accumulation_last(_minimal_hourly_precip())
+
+    assert _daily_value(collapsed, DAY0) == DAY0_TOTAL
+    assert _daily_value(collapsed, DAY1) == DAY1_TOTAL

--- a/tests/test_historical_daily.py
+++ b/tests/test_historical_daily.py
@@ -20,6 +20,7 @@ DAYS_IN_MONTH = 29
 HOURS_PER_DAY = 24
 PREVIOUS_MONTH_TOTAL = 99.0
 PARTIAL_SHORTFALL = 0.5
+JOINED_SAMPLES = 2
 
 
 def _daily_total(day: int) -> float:
@@ -83,6 +84,37 @@ def test_trim_keeps_only_the_target_month_and_closes_its_last_day() -> None:
         expected.append(_daily_total(day))
     values = trimmed.value.isel(latitude=0, longitude=0).to_numpy()
     assert values == pytest.approx(expected)
+
+
+def test_drop_noncore_coords_allows_concat_across_extract_formats() -> None:
+    """A look-ahead crossing from an old extract into a new one must still concatenate.
+
+    Extracts pulled through the newer CDS API carry `number` and `expver` coordinates
+    that the 1950-2023 extracts lack, and `xr.concat` refuses to join datasets whose
+    coordinates differ. This is live at the 2023/2024 seam: closing 31 Dec 2023 reads the
+    January 2024 file from the newer GBD-2025 pull.
+    """
+    time = xr.date_range("2023-12-31T23:00", periods=1, freq="h", use_cftime=False)
+    old = xr.Dataset({"value": (("time",), np.zeros(1))}, coords={"time": time})
+    # `expver` varies along time in the real extracts (size 744), `number` is scalar.
+    new = xr.Dataset(
+        {"value": (("time",), np.zeros(1))},
+        coords={
+            "time": time + np.timedelta64(1, "h"),
+            "expver": (("time",), np.array(["0001"])),
+            "number": 0,
+        },
+    )
+
+    with pytest.raises(ValueError, match="expver"):
+        xr.concat([old, new], dim="time")
+
+    joined = xr.concat(
+        [hd.drop_noncore_coords(old), hd.drop_noncore_coords(new)], dim="time"
+    )
+
+    assert set(joined.coords) == {"time"}
+    assert joined.sizes["time"] == JOINED_SAMPLES
 
 
 def test_missing_lookahead_raises_and_december_looks_into_january(

--- a/tests/test_historical_daily.py
+++ b/tests/test_historical_daily.py
@@ -1,0 +1,107 @@
+"""Tests for the month-boundary handling in historical daily generation (CLIMATE-29)."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from climate_data import constants as cdc
+from climate_data.data import ClimateData
+from climate_data.generate import historical_daily as hd
+from climate_data.generate import utils
+
+# February 2020: a real, short, leap month. Using a whole month matters -- the collapse
+# puts a bin at each end that belongs to the neighbouring month, and a truncated
+# stand-in would place the trailing one inside the target month instead.
+YEAR = "2020"
+MONTH = 2
+DAYS_IN_MONTH = 29
+HOURS_PER_DAY = 24
+PREVIOUS_MONTH_TOTAL = 99.0
+PARTIAL_SHORTFALL = 0.5
+
+
+def _daily_total(day: int) -> float:
+    """A distinct total per day, so any misalignment shows up as an off-by-one."""
+    return float(day + 1)
+
+
+def _month_with_lookahead() -> xr.Dataset:
+    """Hourly samples for the whole month plus the one sample that closes its last day.
+
+    Follows the ERA5 accumulation convention: hours 01..23 of a day rise toward its
+    total, hour 00 holds the *previous* day's completed total, and the day's own total is
+    stamped 00:00 of the next day.
+    """
+    n_time = DAYS_IN_MONTH * HOURS_PER_DAY + 1
+    hourly = np.zeros((n_time, 1, 1), dtype="float64")
+    for day in range(DAYS_IN_MONTH):
+        previous = PREVIOUS_MONTH_TOTAL if day == 0 else _daily_total(day - 1)
+        hourly[day * HOURS_PER_DAY] = previous
+        partial = _daily_total(day) - PARTIAL_SHORTFALL
+        for hour in range(1, HOURS_PER_DAY):
+            hourly[day * HOURS_PER_DAY + hour] = partial * hour / (HOURS_PER_DAY - 1)
+    # The look-ahead: the final day's total, stamped 00:00 of the next month.
+    hourly[-1] = _daily_total(DAYS_IN_MONTH - 1)
+
+    time = xr.date_range(
+        f"{YEAR}-{MONTH:02d}-01", periods=n_time, freq="h", use_cftime=False
+    )
+    return xr.Dataset(
+        {"value": (("time", "latitude", "longitude"), hourly)},
+        coords={"time": time, "latitude": [0.0], "longitude": [0.0]},
+    )
+
+
+def test_trim_keeps_only_the_target_month_and_closes_its_last_day() -> None:
+    """The collapse puts a bin outside the month at each end; the trim removes both.
+
+    Binning on ``(D 00:00, D+1 00:00]`` labels the leading bin with the *previous*
+    month's last day, since it holds that day's closing sample, and appends a trailing
+    empty bin labelled with the next month. Left in place, every month contributes a
+    duplicate date and a NaN at its seams, and ``validate_output`` rejects the year on
+    both day count and NaNs. Meanwhile the final day is closed by the look-ahead sample
+    rather than left at its 23-hour partial.
+
+    Covers the transformation only -- reading the look-ahead out of the next month's file
+    is exercised by the sandbox validation run, not here.
+    """
+    collapsed = utils.daily_accumulation_last(_month_with_lookahead())
+    trimmed = hd.trim_to_month(collapsed, YEAR, MONTH)
+
+    # One bin for the previous month's last day, one empty bin for the next month.
+    assert collapsed.sizes["date"] == DAYS_IN_MONTH + 2
+    assert trimmed.sizes["date"] == DAYS_IN_MONTH
+
+    dates = trimmed.date.to_index()
+    assert set(dates.month) == {MONTH}
+    assert set(dates.day) == set(range(1, DAYS_IN_MONTH + 1))
+
+    expected = []
+    for day in range(DAYS_IN_MONTH):
+        expected.append(_daily_total(day))
+    values = trimmed.value.isel(latitude=0, longitude=0).to_numpy()
+    assert values == pytest.approx(expected)
+
+
+def test_missing_lookahead_raises_and_december_looks_into_january(
+    tmp_path: Path,
+) -> None:
+    """December needs the next *year's* January, and an absent file must be loud.
+
+    ERA5 extracts stop at 2023, so regenerating 2023 requires a January 2024 file that
+    does not exist. Failing loudly is deliberate: the alternative is a silent fallback to
+    the 23-hour partial, and a warning buried in a 74-job cluster log is how CLIMATE-23
+    went unnoticed.
+    """
+    cdata = ClimateData(tmp_path, read_only=True)
+
+    with pytest.raises(FileNotFoundError, match="2024_01"):
+        hd.load_variable_with_lookahead(
+            cdata,
+            cdc.ERA5_VARIABLES.total_precipitation,
+            "2023",
+            "12",
+            cdc.ERA5_DATASETS.reanalysis_era5_land,
+        )


### PR DESCRIPTION
Fixes the ~1.5–1.6x wet bias in `total_precipitation` across the 1950–2023 historical record.
Reported by Anna Rutherford (EOD/WASH).

> **This does not make forecast precipitation correct.** A second, independent bug — CMIP6
> `pr` packed at a 2.83 mm/day ceiling, wrapping 26.4% of cells and making 12.4% negative —
> also feeds the scenarios, and is fixed in **PR2**. After this PR the historical product is
> right; scenario precipitation still is not.

## The bug

ERA5 stamps an accumulation window by its **end**: day D's window is forecast steps 01–24, and
step 24 is stamped `00:00` of day D+1. These are interval labels, not instants.
`groupby("time.date")` buckets hours 00–23, so each bucket opened with the *previous* day's
completed total and never saw its own — and `daily_max` on ERA5-Land then returned
`max(yesterday's total, today's 23-hour partial)`.

## The fix

Both ERA5 datasets now collapse with `resample(closed="right", label="left")`, binning on
`(D 00:00, D+1 00:00]` labelled `D` — one window per day. ERA5-Land takes the closing sample
(`daily_accumulation_last`), single-levels sums its hourly increments
(`daily_accumulation_sum`). `daily_max` is untouched; `max_temperature` is its other, correct
caller.

Since a window is closed by the following hour, generating a month now also reads the first
sample of the next month and trims the out-of-month bins the collapse produces at each end —
gated on `LOOKAHEAD_VARIABLES`, so temperature, wind, humidity and SST are unaffected. A
missing look-ahead raises rather than silently shortening the final day.

## Measured effect

W Europe box, land only, 2020, through the full production path:

| measure | production | corrected | ratio |
|---|---|---|---|
| July mean | 2.5111 mm | 1.5743 mm | 1.595x |
| January mean | 2.3465 mm | 1.5748 mm | 1.490x |
| whole year | 3.6519 mm | 2.3742 mm | 1.538x |
| wet days >0.1 mm, July | 64.0% | 49.3% | 1.299x |

All 74 years regenerated into a sandbox: 1.45–1.47x on a fixed land mask, leap-aware day
counts, zero NaNs, 72/72 jobs clean. **That run used the full working branch, not these four
commits in isolation** — strong evidence for the approach, not a clean-room validation of this
diff.

## Not in this PR

First of three stacked PRs. Deliberately deferred, not overlooked:

- The CMIP6 `pr` encoding corruption above, plus the extract data-loss and filename bugs found
  with it → **PR2**
- `.last()` defaults to `skipna=True`, so a missing closing sample silently returns the
  23-hour partial → **PR2**
- The look-ahead is taken on trust — no midnight check, and `xr.concat` defaults to
  `join="outer"` → **PR2**
- The `FileNotFoundError` names an extract the CLI will reject (`--year` is bound to
  `HISTORY_YEARS`) → **PR2**
- Doc corrections: `daily_last` doesn't exist, and the format seam is two seams, not one →
  **PR2**
- Per-member fan-out, `docs/running.md`, `uint16` encoding → **PR3**

Note `14d9e31` is not independently runnable — `resample` emits an out-of-month bin at each
end, so a real year fails `validate_output` until `3799c66`. Tests pass at every commit.

**Please don't squash-merge** — PR2 and PR3 are stacked on this branch.

## Background

[Commit-by-commit walkthrough, with side-by-side and inline
diffs](https://docs.sae.ihme.washington.edu/billg/reviews/climate-29/) — written while
deciding this split, so it walks a **five**-commit range that also includes the CMIP6 encoding
commit since deferred to PR2. Its "what this range does not contain" table is the fullest
account of why the boundaries fall where they do.

---
8 tests passing; `ruff`, `mypy` (strict), `kacl-cli`, `mkdocs` clean. 7 files, +435 / −9.
All four commits have been through an independent cold review.
